### PR TITLE
FEATURE: Adding Facebook to SocialProfiles

### DIFF
--- a/.netlify/state.json
+++ b/.netlify/state.json
@@ -1,0 +1,3 @@
+{
+	"siteId": "f2a956ab-e5b9-49fb-8f87-ecc6606e928a"
+}

--- a/content/sections/contact/contact.json
+++ b/content/sections/contact/contact.json
@@ -7,7 +7,7 @@
     "alt": "ideaSquared Logo"
   },
   "socialProfiles": {
-    "from": ["Twitter", "Github", "Mail"],
+    "from": ["Twitter", "Github", "Facebook", "Mail"],
     "showIcons": true
   }
 }

--- a/content/sections/hero/hero.json
+++ b/content/sections/hero/hero.json
@@ -16,7 +16,7 @@
   },
   "description": "A community of tech enthusiasts building products from inception to production.",
   "socialProfiles": {
-    "from": ["Twitter", "Github", "Mail"],
+    "from": ["Twitter", "Github", "Facebook", "Mail"],
     "showIcons": true
   }
 }

--- a/content/settings.json
+++ b/content/settings.json
@@ -11,7 +11,8 @@
     "social": {
       "github": "https://github.com/ideaSquared",
       "mail": "mailto:hello@ideasquared.co.uk",
-      "twitter": "https://twitter.com/ideaSquared"
+      "twitter": "https://twitter.com/ideaSquared",
+      "facebook": "https://facebook.com/ideaSquared"
     }
   },
   "siteConfiguration": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "gatsby": "^5.0.1",
-    "gatsby-theme-portfolio-minimal": "latest",
+    "gatsby-theme-portfolio-minimal": "^4.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Once the [PR](https://github.com/konstantinmuenster/gatsby-theme-portfolio-minimal/pull/40) was merged in the main branch of the portfolio template we've been able to use the social profile Facebook icon.

Porting that across.