### PR TITLE
Fix run-together hyphens across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>ideaSquared -Bold ideas, built properly.</title>
+<title>ideaSquared &mdash; Bold ideas, built properly.</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="ideaSquared (i²) is a UK venture studio. We build, launch and scale digital ventures with social and commercial upside -without recreating the same plumbing every time.">
+<meta name="description" content="ideaSquared (i²) is a UK venture studio. We build, launch and scale digital ventures with social and commercial upside &mdash; without recreating the same plumbing every time.">
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
 <link rel="stylesheet" href="styles/tokens.css">
 <link rel="stylesheet" href="styles/site.css">
@@ -100,7 +100,7 @@
 
   <div class="project-grid" id="project-grid">
 
-    <a class="project-card" href="ventures/adopt-dont-shop/" data-tag="Live" aria-label="AdoptDontShop -read the venture brief">
+    <a class="project-card" href="ventures/adopt-dont-shop/" data-tag="Live" aria-label="AdoptDontShop &mdash; read the venture brief">
       <div class="project-top">
         <span class="chip">Alpha · in build</span>
         <span class="project-meta">Pet adoption · UK</span>
@@ -113,7 +113,7 @@
       </div>
     </a>
 
-    <a class="project-card dark" href="ventures/pairflix/" data-tag="Live" aria-label="Pairflix -read the venture brief">
+    <a class="project-card dark" href="ventures/pairflix/" data-tag="Live" aria-label="Pairflix &mdash; read the venture brief">
       <div class="project-top">
         <span class="chip">Alpha · in build</span>
         <span class="project-meta">Streaming · UK households</span>

--- a/journal/index.html
+++ b/journal/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Journal -ideaSquared</title>
+<title>Journal &mdash; ideaSquared</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Dated build log across the ideaSquared ventures, newest first, with venture-tagged entries and per-product current-state snapshots.">
 <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
@@ -33,7 +33,7 @@
 <section class="subpage-hero">
   <span class="eyebrow">The journal</span>
   <h1>What's shipping across the studio, in the open.</h1>
-  <p>Dated entries from the live ventures, newest first. Each entry links to the <a href="../ventures/">venture brief</a> for the full current snapshot -roadmap, stack and stage.</p>
+  <p>Dated entries from the live ventures, newest first. Each entry links to the <a href="../ventures/">venture brief</a> for the full current snapshot &mdash; roadmap, stack and stage.</p>
 </section>
 
 <section class="venture-section" aria-labelledby="entries">
@@ -50,7 +50,7 @@
         <span style="font-size: 12px; color: var(--fg-muted);">25 May 2026</span>
       </div>
       <h4>Roadmap re-baselined to closed beta Aug–Sep 2026.</h4>
-      <p>Original §15 beta target (Q4 2025) was missed. The May 2026 re-baseline replaces it with seven sequenced milestones: legal foundation, data protection package, platform hardening, closed beta, trust &amp; safety, payments &amp; commercial, and public launch in November. Demand signal preserved -5 lister LOIs and a 1,000+ adopter waitlist carried in.</p>
+      <p>Original §15 beta target (Q4 2025) was missed. The May 2026 re-baseline replaces it with seven sequenced milestones: legal foundation, data protection package, platform hardening, closed beta, trust &amp; safety, payments &amp; commercial, and public launch in November. Demand signal preserved &mdash; 5 lister LOIs and a 1,000+ adopter waitlist carried in.</p>
     </article>
 
     <article class="venture-card">
@@ -68,7 +68,7 @@
         <span style="font-size: 12px; color: var(--fg-muted);">25 May 2026</span>
       </div>
       <h4>Scope cuts logged.</h4>
-      <p>Three features dropped on purpose: a rescue ratings system (against principle), an adopter "wishlist" (animal-as-listing -no thanks), and premium rescue placements (the £40k cheque we turned down).</p>
+      <p>Three features dropped on purpose: a rescue ratings system (against principle), an adopter "wishlist" (animal-as-listing &mdash; no thanks), and premium rescue placements (the £40k cheque we turned down).</p>
     </article>
 
     <article class="venture-card">
@@ -95,7 +95,7 @@
         <span style="font-size: 12px; color: var(--fg-muted);">Apr 2026</span>
       </div>
       <h4>Early alpha state captured.</h4>
-      <p>Platform stack standing -three apps (client, admin, backend), JWT auth, watchlist + partner matching, TMDB integration, TypeScript strict mode, full test suite passing, multi-stage Docker builds behind Nginx. No public users yet; matcher and partner-pairing UX in flight before opening a closed alpha.</p>
+      <p>Platform stack standing &mdash; three apps (client, admin, backend), JWT auth, watchlist + partner matching, TMDB integration, TypeScript strict mode, full test suite passing, multi-stage Docker builds behind Nginx. No public users yet; matcher and partner-pairing UX in flight before opening a closed alpha.</p>
     </article>
 
   </div>

--- a/studio/index.html
+++ b/studio/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<title>Studio -ideaSquared</title>
+		<title>Studio &mdash; ideaSquared</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta
 			name="description"
-			content="How the ideaSquared studio is set up -operating principles, the venture lifecycle, and the engineering defaults every project inherits."
+			content="How the ideaSquared studio is set up &mdash; operating principles, the venture lifecycle, and the engineering defaults every project inherits."
 		/>
 		<link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
 		<link rel="stylesheet" href="../styles/tokens.css" />
@@ -66,7 +66,7 @@
 				<h1>The studio is the platform. The ventures are the products.</h1>
 				<p>
 					i² runs as a small operating studio: one TypeScript stack, one CI
-					pipeline, one set of conventions -every venture inherits the lot. The
+					pipeline, one set of conventions &mdash; every venture inherits the lot. The
 					platform isn't glamorous, but it's the thing that lets a small team
 					ship like a large one.
 				</p>
@@ -110,7 +110,7 @@
 						<h4>PRODUCT</h4>
 						<p>
 							Venture spins out as an independent legal entity, takes follow-on
-							capital and scales -or hits its kill criteria and sunsets cleanly.
+							capital and scales &mdash; or hits its kill criteria and sunsets cleanly.
 						</p>
 					</article>
 				</div>
@@ -326,7 +326,7 @@
 					<article class="venture-card">
 						<h4>Schema-first contracts</h4>
 						<p>
-							Typed contracts at every boundary -API, events, forms. Validated
+							Typed contracts at every boundary &mdash; API, events, forms. Validated
 							at the seam, not in the middle.
 						</p>
 					</article>
@@ -340,7 +340,7 @@
 					<article class="venture-card">
 						<h4>Observability before scale</h4>
 						<p>
-							Logs, metrics and traces wired in from day one -not added in panic
+							Logs, metrics and traces wired in from day one &mdash; not added in panic
 							later.
 						</p>
 					</article>

--- a/thesis/index.html
+++ b/thesis/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Thesis -ideaSquared</title>
+<title>Thesis &mdash; ideaSquared</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="The bet behind ideaSquared. Why a venture studio, why the UK, and what we believe about how digital ventures actually fail.">
 <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
@@ -33,7 +33,7 @@
 <section class="subpage-hero">
   <span class="eyebrow signal">The thesis</span>
   <h1>Startups don't fail at ideation. They fail at execution.</h1>
-  <p>Most digital ventures fail at the boring middle -the part where someone has to make decisions about auth, payments, infra, hiring, compliance and go-to-market all at once, usually for the first time. ideaSquared exists to amortise that middle across a portfolio.</p>
+  <p>Most digital ventures fail at the boring middle &mdash; the part where someone has to make decisions about auth, payments, infra, hiring, compliance and go-to-market all at once, usually for the first time. ideaSquared exists to amortise that middle across a portfolio.</p>
 </section>
 
 <section class="venture-section" aria-labelledby="vision">
@@ -42,7 +42,7 @@
     <h2 id="vision">What we are aiming at.</h2>
   </div>
   <blockquote><strong>Vision.</strong> Turning bold ideas into ventures that create meaningful change.</blockquote>
-  <blockquote><strong>Mission.</strong> To be the most reliable place in the UK to take a bold digital idea from concept to launched, defensible business -without recreating the same plumbing every time.</blockquote>
+  <blockquote><strong>Mission.</strong> To be the most reliable place in the UK to take a bold digital idea from concept to launched, defensible business &mdash; without recreating the same plumbing every time.</blockquote>
 </section>
 
 <section class="venture-section" aria-labelledby="problem">
@@ -54,7 +54,7 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Plumbing tax</h4>
-      <p>Auth, payments, observability, design system, hiring, compliance -every new venture pays for the same scaffolding from scratch.</p>
+      <p>Auth, payments, observability, design system, hiring, compliance &mdash; every new venture pays for the same scaffolding from scratch.</p>
     </article>
     <article class="venture-card">
       <h4>Late validation</h4>
@@ -76,7 +76,7 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Compounding playbook</h4>
-      <p>Each venture sharpens the studio's GTM, hiring and tech defaults -so every cohort costs less to launch than the last.</p>
+      <p>Each venture sharpens the studio's GTM, hiring and tech defaults &mdash; so every cohort costs less to launch than the last.</p>
     </article>
     <article class="venture-card">
       <h4>Shared platform</h4>
@@ -122,7 +122,7 @@
     <article class="venture-card">
       <div class="num">3</div>
       <h4>Ventures at scale</h4>
-      <p>Three above £1m ARR -the threshold at which they fund themselves.</p>
+      <p>Three above £1m ARR &mdash; the threshold at which they fund themselves.</p>
     </article>
     <article class="venture-card">
       <div class="num">1</div>
@@ -132,7 +132,7 @@
     <article class="venture-card">
       <div class="num">£100m+</div>
       <h4>Portfolio EV</h4>
-      <p>Combined enterprise value across the portfolio -the studio's compounding output.</p>
+      <p>Combined enterprise value across the portfolio &mdash; the studio's compounding output.</p>
     </article>
   </div>
 </section>

--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>AdoptDontShop -Adoption made simple · ideaSquared</title>
+<title>AdoptDontShop &mdash; Adoption made simple · ideaSquared</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="AdoptDontShop is a swipe-based pet adoption platform connecting UK rescue pets with the right humans. Closed beta Aug–Sep 2026, public launch Nov 2026. A venture of the ideaSquared studio.">
 <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
@@ -35,7 +35,7 @@
     <div>
       <span class="eyebrow signal">Venture · in build</span>
       <h1 id="ads-name">AdoptDontShop.</h1>
-      <p class="lede">Adoption made simple. A swipe-based pet adoption platform connecting UK rescue pets with the right humans -built mobile-first, free for adopters.</p>
+      <p class="lede">Adoption made simple. A swipe-based pet adoption platform connecting UK rescue pets with the right humans &mdash; built mobile-first, free for adopters.</p>
       <div class="meta">
         <span class="chip">Pet adoption</span>
         <span class="chip">UK-first</span>
@@ -67,7 +67,7 @@
   <div class="venture-grid-2">
     <article class="venture-card">
       <h4>Rescues lack modern tools</h4>
-      <p>Most run on spreadsheets, email and Facebook posts. Listings, applications, home checks and outcomes all live in different places -or no place at all.</p>
+      <p>Most run on spreadsheets, email and Facebook posts. Listings, applications, home checks and outcomes all live in different places &mdash; or no place at all.</p>
     </article>
     <article class="venture-card">
       <h4>Adopters bounce between sites</h4>
@@ -125,7 +125,7 @@
     <tbody>
       <tr><th scope="row">Rescue SaaS</th><td>Rescues</td><td>Tiered monthly subscription</td></tr>
       <tr><th scope="row">Affiliate revenue</th><td>Vets, insurers, pet food, accessories</td><td>Rev-share on adopter conversion</td></tr>
-      <tr><th scope="row">Premium adopter</th><td>Adopters</td><td>Optional -priority matching, extras</td></tr>
+      <tr><th scope="row">Premium adopter</th><td>Adopters</td><td>Optional &mdash; priority matching, extras</td></tr>
     </tbody>
   </table>
 </section>
@@ -174,12 +174,12 @@
   <div class="head">
     <span class="eyebrow">Where we are · May 2026</span>
     <h2 id="status">Alpha build is feature-complete. Compliance is the gate.</h2>
-    <p>The core adoption flow ships end-to-end in the alpha. The path to closed beta now runs through legal foundation, the data protection package and platform hardening -not more product code.</p>
+    <p>The core adoption flow ships end-to-end in the alpha. The path to closed beta now runs through legal foundation, the data protection package and platform hardening &mdash; not more product code.</p>
   </div>
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, and the full Docker dev + prod environment -all live on the TypeScript monorepo.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, and the full Docker dev + prod environment &mdash; all live on the TypeScript monorepo.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one API</h4>
@@ -209,7 +209,7 @@
     <span class="icon" aria-hidden="true">✂</span>
     <div>
       <strong>What we cut from scope</strong>
-      <p style="margin: 4px 0 0;">A rescue ratings system (against principle), a "wishlist" feature (animal-as-listing -no thanks), and premium rescue placements (the £40k cheque we turned down). Build-in-public notes live on the <a href="../../journal/">studio journal</a>.</p>
+      <p style="margin: 4px 0 0;">A rescue ratings system (against principle), a "wishlist" feature (animal-as-listing &mdash; no thanks), and premium rescue placements (the £40k cheque we turned down). Build-in-public notes live on the <a href="../../journal/">studio journal</a>.</p>
     </div>
   </div>
 </section>
@@ -265,7 +265,7 @@
     <article class="venture-card">
       <div class="num">50,000</div>
       <h4>Successful adoptions by 2030</h4>
-      <p>The medium-term operating goal -the number that turns AdoptDontShop into a category leader for ethical adoption in the UK.</p>
+      <p>The medium-term operating goal &mdash; the number that turns AdoptDontShop into a category leader for ethical adoption in the UK.</p>
     </article>
     <article class="venture-card">
       <h4>Reduced euthanasia rates</h4>
@@ -273,7 +273,7 @@
     </article>
     <article class="venture-card">
       <h4>"Adopt first" before "buy"</h4>
-      <p>The cultural shift we're after -making adoption the default expectation, not the more difficult option.</p>
+      <p>The cultural shift we're after &mdash; making adoption the default expectation, not the more difficult option.</p>
     </article>
   </div>
 </section>

--- a/ventures/index.html
+++ b/ventures/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Ventures -ideaSquared</title>
+<title>Ventures &mdash; ideaSquared</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="The ideaSquared portfolio: two ventures in active build, two pipeline concepts, and the open-source studio code behind them.">
 <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
@@ -33,7 +33,7 @@
 <section class="subpage-hero">
   <span class="eyebrow">The portfolio</span>
   <h1>Two ventures in build. Two pipeline concepts. One shared platform.</h1>
-  <p>Active ventures are products under active development on the studio platform -neither has opened to public users yet. Pipeline concepts are still in validation -willingness-to-pay first, code second.</p>
+  <p>Active ventures are products under active development on the studio platform &mdash; neither has opened to public users yet. Pipeline concepts are still in validation &mdash; willingness-to-pay first, code second.</p>
 </section>
 
 <section class="venture-section" aria-labelledby="live">
@@ -43,7 +43,7 @@
   </div>
   <div class="project-grid">
 
-    <a class="project-card" href="adopt-dont-shop/" aria-label="AdoptDontShop -read the venture brief">
+    <a class="project-card" href="adopt-dont-shop/" aria-label="AdoptDontShop &mdash; read the venture brief">
       <div class="project-top">
         <span class="chip">Alpha · in build</span>
         <span class="project-meta">Pet adoption · UK</span>
@@ -56,13 +56,13 @@
       </div>
     </a>
 
-    <a class="project-card dark" href="pairflix/" aria-label="Pairflix -read the venture brief">
+    <a class="project-card dark" href="pairflix/" aria-label="Pairflix &mdash; read the venture brief">
       <div class="project-top">
         <span class="chip">Alpha · in build</span>
         <span class="project-meta">Streaming · UK households</span>
       </div>
       <h3 class="project-name">Pairflix</h3>
-      <p class="project-desc">An AI matcher that turns the nightly "what shall we watch?" argument into a 30-second decision -across Netflix, Prime, Disney+ and friends.</p>
+      <p class="project-desc">An AI matcher that turns the nightly "what shall we watch?" argument into a 30-second decision &mdash; across Netflix, Prime, Disney+ and friends.</p>
       <div class="project-foot">
         <span class="project-stake-label">Read</span>
         <span class="project-stake-n">Venture brief →</span>
@@ -87,7 +87,7 @@
     <article class="venture-card">
       <span class="chip" style="align-self: flex-start; margin-bottom: 4px;">Pipeline · 2026</span>
       <h4>FinTech (TBD)</h4>
-      <p>A second concept in validation. Same gate as everything else -prove the demand, set the kill criteria, then we build.</p>
+      <p>A second concept in validation. Same gate as everything else &mdash; prove the demand, set the kill criteria, then we build.</p>
     </article>
   </div>
 </section>
@@ -96,7 +96,7 @@
   <div class="head">
     <span class="eyebrow">Studio toolkit</span>
     <h2 id="toolkit">Open-source code that supports the ventures.</h2>
-    <p>Older repos and supporting tools that live alongside the active ventures on the GitHub org. Not commercial ventures -code we kept open because someone might want it.</p>
+    <p>Older repos and supporting tools that live alongside the active ventures on the GitHub org. Not commercial ventures &mdash; code we kept open because someone might want it.</p>
   </div>
   <div class="venture-grid-3">
 
@@ -115,25 +115,25 @@
     <article class="venture-card">
       <span class="chip" style="align-self: flex-start; margin-bottom: 4px;">Maintained</span>
       <h4><a href="https://github.com/ideaSquared/spotify-queue">spotify-queue</a></h4>
-      <p>A shared-queue overlay for Spotify -drop a link, hand the room a soundtrack.</p>
+      <p>A shared-queue overlay for Spotify &mdash; drop a link, hand the room a soundtrack.</p>
     </article>
 
     <article class="venture-card">
       <span class="chip" style="align-self: flex-start; margin-bottom: 4px;">Maintained</span>
       <h4><a href="https://github.com/ideaSquared/tarkovcommunity">tarkovcommunity</a></h4>
-      <p>A community hub for Escape from Tarkov players -guides and shared loadouts.</p>
+      <p>A community hub for Escape from Tarkov players &mdash; guides and shared loadouts.</p>
     </article>
 
     <article class="venture-card">
       <span class="chip" style="align-self: flex-start; margin-bottom: 4px;">Archived</span>
       <h4><a href="https://github.com/ideaSquared/path-of-titans">path-of-titans</a></h4>
-      <p>Where the studio org started -a community map and tracker for the dinosaur MMO. The first repo on the org.</p>
+      <p>Where the studio org started &mdash; a community map and tracker for the dinosaur MMO. The first repo on the org.</p>
     </article>
 
     <article class="venture-card">
       <span class="chip success" style="align-self: flex-start; margin-bottom: 4px;">Active</span>
       <h4><a href="https://github.com/ideaSquared/ideasquared-website">ideasquared-website</a></h4>
-      <p>This site. Static, vanilla, open source -the studio's own front door.</p>
+      <p>This site. Static, vanilla, open source &mdash; the studio's own front door.</p>
     </article>
 
   </div>

--- a/ventures/pairflix/index.html
+++ b/ventures/pairflix/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Pairflix -Streaming is better together · ideaSquared</title>
+<title>Pairflix &mdash; Streaming is better together · ideaSquared</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Pairflix is an AI-powered matcher that helps couples and households decide what to watch in 30 seconds. A venture of the ideaSquared studio.">
 <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
@@ -35,7 +35,7 @@
     <div>
       <span class="eyebrow signal">Venture · in build</span>
       <h1 id="pairflix-name">Pairflix.</h1>
-      <p class="lede">Streaming is better together. Pairflix turns the nightly "what shall we watch?" argument into a 30-second decision -across Netflix, Prime, Disney+ and friends.</p>
+      <p class="lede">Streaming is better together. Pairflix turns the nightly "what shall we watch?" argument into a 30-second decision &mdash; across Netflix, Prime, Disney+ and friends.</p>
       <div class="meta">
         <span class="chip">Web &amp; AI</span>
         <span class="chip">UK households</span>
@@ -72,7 +72,7 @@
     <article class="venture-card">
       <div class="num">2.5 hrs</div>
       <h4>Daily streaming time</h4>
-      <p>UK adults stream for roughly two and a half hours a day -most of it on platforms designed for individual taste profiles.</p>
+      <p>UK adults stream for roughly two and a half hours a day &mdash; most of it on platforms designed for individual taste profiles.</p>
     </article>
     <article class="venture-card">
       <div class="num">High</div>
@@ -86,12 +86,12 @@
   <div class="head">
     <span class="eyebrow">The solution</span>
     <h2 id="solution">A relationship-first recommendation layer.</h2>
-    <p>Pairflix sits on top of the streaming subscriptions a household already pays for and recommends a single, agreed title -based on both partners' tastes, mood and the time they've actually got.</p>
+    <p>Pairflix sits on top of the streaming subscriptions a household already pays for and recommends a single, agreed title &mdash; based on both partners' tastes, mood and the time they've actually got.</p>
   </div>
   <div class="venture-grid-2">
     <article class="venture-card">
       <h4>Pair profile</h4>
-      <p>Two -or more -taste profiles joined into one shared recommender. The whole household, not just one viewer.</p>
+      <p>Two &mdash; or more &mdash; taste profiles joined into one shared recommender. The whole household, not just one viewer.</p>
     </article>
     <article class="venture-card">
       <h4>Mood &amp; time inputs</h4>
@@ -103,7 +103,7 @@
     </article>
     <article class="venture-card">
       <h4>Watch-together history</h4>
-      <p>Tracks what you've actually agreed on -not just what you started -and learns the household's real taste over time.</p>
+      <p>Tracks what you've actually agreed on &mdash; not just what you started &mdash; and learns the household's real taste over time.</p>
     </article>
   </div>
 </section>
@@ -137,7 +137,7 @@
       <tr><th scope="col">Stream</th><th scope="col">Payer</th><th scope="col">Pricing</th></tr>
     </thead>
     <tbody>
-      <tr><th scope="row">Premium subscription</th><td>Couples &amp; households</td><td>Monthly fee -unlimited matches &amp; cross-platform</td></tr>
+      <tr><th scope="row">Premium subscription</th><td>Couples &amp; households</td><td>Monthly fee &mdash; unlimited matches &amp; cross-platform</td></tr>
       <tr><th scope="row">Affiliate revenue</th><td>Streamers &amp; content partners</td><td>Rev-share on signups</td></tr>
       <tr><th scope="row">Free tier</th><td>Adopters</td><td>Limited matches per day, ad-light</td></tr>
     </tbody>
@@ -147,13 +147,13 @@
 <section class="venture-section" aria-labelledby="status">
   <div class="head">
     <span class="eyebrow">Where we are</span>
-    <h2 id="status">Early alpha -pre-launch, no public users yet.</h2>
+    <h2 id="status">Early alpha &mdash; pre-launch, no public users yet.</h2>
     <p>The platform stack is in place; the product hasn't opened to outside testers. No waitlist, no beta cohort, no public release date. We'll announce when the build clears its quality bar.</p>
   </div>
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Three apps in build</h4>
-      <p>Client (browse, watchlists, partner matching), Admin (user management, content moderation) and a Node/Express + Postgres backend -all in the same TypeScript monorepo on the studio platform.</p>
+      <p>Client (browse, watchlists, partner matching), Admin (user management, content moderation) and a Node/Express + Postgres backend &mdash; all in the same TypeScript monorepo on the studio platform.</p>
     </article>
     <article class="venture-card">
       <h4>Platform readiness</h4>


### PR DESCRIPTION
## Summary

Across every HTML page, lots of body copy, titles, meta descriptions and aria-labels had `-word` patterns (a hyphen jammed against the following word with no space), e.g. `upside -without`, `Ventures -ideaSquared`, `Pairflix -read the venture brief`. They read as typos and looked wrong inline.

Replaced these with proper em-dashes (`&mdash;`) surrounded by spaces, matching the convention already used elsewhere (e.g. the home-page lede and the IDEA stage description on `index.html`).

Files touched: `index.html`, `journal/index.html`, `studio/index.html`, `thesis/index.html`, `ventures/index.html`, `ventures/adopt-dont-shop/index.html`, `ventures/pairflix/index.html`.

## Test plan

- [ ] Open each page in a browser and confirm dashes render as em-dashes with spaces around them
- [ ] Check browser tab titles render correctly (`ideaSquared — Bold ideas, built properly.`, etc.)
- [ ] Spot-check on mobile width that nothing wraps oddly around the em-dashes


---
_Generated by [Claude Code](https://claude.ai/code/session_01V3gB6FgSd4Rqwkmo6oHLfg)_