### PR TITLE
feat(ventures): update AdoptDontShop status for microservices milestone

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -179,11 +179,11 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing &mdash; all live on the TypeScript monorepo.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
     </article>
     <article class="venture-card">
-      <h4>Three frontends, one API</h4>
-      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize backing PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx.</p>
+      <h4>Three frontends, one platform</h4>
+      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. Services communicate over gRPC + NATS as the platform migrates to a domain-per-service architecture.</p>
     </article>
     <article class="venture-card">
       <h4>Demand signal preserved</h4>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updates the AdoptDontShop venture page to reflect today's major engineering milestone: notifications and auth extracted as independent gRPC/NATS services behind a strangler-fig gateway, pets extraction in progress
- Renames "Three frontends, one API" → "Three frontends, one platform" and expands the tech stack description to surface the distributed architecture story
- Expands "Shipped in the alpha" copy to call out the microservices migration

## What changed in the codebase (today, 5 Jun 2026)

24 PRs merged across Phases 0–3.3a of the CAD-style microservices migration:
- Phases 0–0f: shared packages (proto codegen, authz helpers, OTel/Sentry observability, strangler-fig gateway)
- Phases 1.1–1.6: full notifications microservice extracted (schema, gRPC, NATS subscribers, WebSocket fan-out, gateway cutover)
- Phases 2.1–2.6: full auth microservice extracted (schema, proto, handlers, gRPC server, downstream event subscribers, gateway middleware, gateway cutover + rate limiting)
- Phases 3.1–3.3a: pets microservice boot skeleton, schema + migrations, proto + gRPC stubs

## Notion changelog

Also updated the [Changelog / Release Notes](https://app.notion.com/p/1af1f6f299ab4477b8702cf201e06a7e) page in Notion with two new entries under AdoptDontShop v0.x — In build · June 2026:
- Microservices architecture migration
- Auth endpoint rate limiting

## Test plan

- [ ] Review the rendered ADS venture page copy — "Shipped in the alpha" and "Three frontends, one platform" cards
- [ ] Confirm Notion changelog shows the two new June 2026 entries for AdoptDontShop

https://claude.ai/code/session_01D6u6zkEPjfkGQCErs8BXGA
EOF

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6u6zkEPjfkGQCErs8BXGA)_