### PR TITLE
Add dark/light theme toggle that follows browser preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
 <link rel="stylesheet" href="styles/tokens.css">
 <link rel="stylesheet" href="styles/site.css">
+<script>(function(){try{var t=localStorage.getItem('i2-theme');document.documentElement.setAttribute('data-theme',t==='light'||t==='dark'?t:'auto');}catch(e){document.documentElement.setAttribute('data-theme','auto');}})();</script>
 </head>
 <body class="i2">
 <a class="skip-link" href="#main">Skip to main content</a>
@@ -21,6 +22,10 @@
       <a href="/studio/"   data-nav="/studio/">Studio</a>
       <a href="/journal/"  data-nav="/journal/">Journal</a>
     </nav>
+    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m4.93 19.07 1.41-1.41"/><path d="m17.66 6.34 1.41-1.41"/></svg>
+    </button>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg>
     </button>

--- a/journal/index.html
+++ b/journal/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 <link rel="stylesheet" href="../styles/tokens.css">
 <link rel="stylesheet" href="../styles/site.css">
+<script>(function(){try{var t=localStorage.getItem('i2-theme');document.documentElement.setAttribute('data-theme',t==='light'||t==='dark'?t:'auto');}catch(e){document.documentElement.setAttribute('data-theme','auto');}})();</script>
 </head>
 <body class="i2">
 <a class="skip-link" href="#main">Skip to main content</a>
@@ -21,6 +22,10 @@
       <a href="../studio/"   data-nav="/studio/">Studio</a>
       <a href="../journal/"  data-nav="/journal/">Journal</a>
     </nav>
+    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m4.93 19.07 1.41-1.41"/><path d="m17.66 6.34 1.41-1.41"/></svg>
+    </button>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg>
     </button>

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -1,4 +1,57 @@
 (() => {
+  // ---- Theme toggle ---------------------------------------------------
+  // States: "auto" (follow OS), "light", "dark".
+  // Stored only when the user makes an explicit choice; absence == auto.
+  const THEME_KEY = 'i2-theme';
+  const root = document.documentElement;
+  const stored = (() => {
+    try { return localStorage.getItem(THEME_KEY); } catch (e) { return null; }
+  })();
+  const initial = stored === 'light' || stored === 'dark' ? stored : 'auto';
+  root.setAttribute('data-theme', initial);
+
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  const resolved = () => {
+    const t = root.getAttribute('data-theme');
+    if (t === 'light' || t === 'dark') return t;
+    return mql.matches ? 'dark' : 'light';
+  };
+
+  const buttons = document.querySelectorAll('[data-theme-toggle]');
+  const syncButtons = () => {
+    const next = resolved() === 'dark' ? 'light' : 'dark';
+    buttons.forEach((btn) => {
+      btn.setAttribute('aria-label', `Switch to ${next} theme`);
+      btn.setAttribute('title', `Switch to ${next} theme`);
+      btn.setAttribute('aria-pressed', String(resolved() === 'dark'));
+    });
+  };
+  syncButtons();
+
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const next = resolved() === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-theme', next);
+      try { localStorage.setItem(THEME_KEY, next); } catch (e) {}
+      syncButtons();
+    });
+  });
+
+  // Reflect OS changes while in auto mode.
+  const onMqlChange = () => {
+    if (root.getAttribute('data-theme') === 'auto') syncButtons();
+  };
+  if (mql.addEventListener) mql.addEventListener('change', onMqlChange);
+  else if (mql.addListener) mql.addListener(onMqlChange);
+
+  // Sync across tabs.
+  window.addEventListener('storage', (e) => {
+    if (e.key !== THEME_KEY) return;
+    const t = e.newValue === 'light' || e.newValue === 'dark' ? e.newValue : 'auto';
+    root.setAttribute('data-theme', t);
+    syncButtons();
+  });
+
   const nav = document.getElementById('nav');
   if (nav) {
     const onScroll = () => nav.classList.toggle('is-scrolled', window.scrollY > 12);

--- a/studio/index.html
+++ b/studio/index.html
@@ -11,6 +11,7 @@
 		<link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
 		<link rel="stylesheet" href="../styles/tokens.css" />
 		<link rel="stylesheet" href="../styles/site.css" />
+		<script>(function(){try{var t=localStorage.getItem('i2-theme');document.documentElement.setAttribute('data-theme',t==='light'||t==='dark'?t:'auto');}catch(e){document.documentElement.setAttribute('data-theme','auto');}})();</script>
 	</head>
 	<body class="i2">
 		<a class="skip-link" href="#main">Skip to main content</a>
@@ -29,6 +30,10 @@
 					<a href="../studio/" data-nav="/studio/">Studio</a>
 					<a href="../journal/" data-nav="/journal/">Journal</a>
 				</nav>
+				<button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+					<svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+					<svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m4.93 19.07 1.41-1.41"/><path d="m17.66 6.34 1.41-1.41"/></svg>
+				</button>
 				<button
 					class="nav-toggle"
 					id="nav-toggle"

--- a/styles/site.css
+++ b/styles/site.css
@@ -55,11 +55,11 @@ img { display: block; max-width: 100%; }
 .btn-primary { background: var(--i2-signal-500); color: var(--i2-navy-900); }
 .btn-primary:hover { background: var(--i2-signal-600); color: #fff; transform: translateY(-1px); }
 
-.btn-secondary { background: var(--i2-navy-900); color: #fff; }
-.btn-secondary:hover { background: var(--i2-navy-800); transform: translateY(-1px); }
+.btn-secondary { background: var(--fg); color: var(--bg); }
+.btn-secondary:hover { background: var(--fg-body); color: var(--bg); transform: translateY(-1px); }
 
 .btn-ghost { background: transparent; color: var(--fg); border-color: var(--line-strong); }
-.btn-ghost:hover { background: #fff; border-color: var(--i2-navy-900); }
+.btn-ghost:hover { background: var(--bg-raised); border-color: var(--fg); }
 
 .btn-ghost-dark { background: transparent; color: #fff; border-color: rgba(255,255,255,0.2); }
 .btn-ghost-dark:hover { background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.6); }
@@ -112,7 +112,7 @@ button:focus-visible {
   font-weight: 600;
   letter-spacing: 0.01em;
   border: 1px solid;
-  background: #fff;
+  background: var(--bg-raised);
   color: var(--fg);
   border-color: var(--line-strong);
 }
@@ -136,7 +136,7 @@ button:focus-visible {
   padding: 0 24px;
 }
 .nav-inner {
-  background: rgba(247, 246, 242, 0.55);
+  background: var(--nav-bg, rgba(247, 246, 242, 0.55));
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border: 1px solid var(--line);
@@ -148,7 +148,7 @@ button:focus-visible {
   gap: 14px;
   transition: background var(--dur-base) var(--ease-out);
 }
-.nav.is-scrolled .nav-inner { background: rgba(247, 246, 242, 0.85); }
+.nav.is-scrolled .nav-inner { background: var(--nav-bg-scrolled, rgba(247, 246, 242, 0.85)); }
 .nav-brand {
   display: inline-flex;
   align-items: center;
@@ -176,8 +176,8 @@ button:focus-visible {
   border-radius: 999px;
   transition: background 180ms;
 }
-.nav-links a:hover { background: rgba(8,24,42,0.05); }
-.nav-links a.is-active { background: rgba(8,24,42,0.08); }
+.nav-links a:hover { background: var(--nav-link-hover, rgba(8,24,42,0.05)); }
+.nav-links a.is-active { background: var(--nav-link-active, rgba(8,24,42,0.08)); }
 .nav-toggle { display: none; }
 
 /* ---------- Hero ---------- */
@@ -247,7 +247,7 @@ button:focus-visible {
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  background: #fff;
+  background: var(--bg-raised);
   border: 1px solid var(--line);
   border-radius: 18px;
   overflow: hidden;
@@ -302,7 +302,7 @@ button:focus-visible {
 }
 .filter { display: flex; gap: 8px; flex-wrap: wrap; }
 .filter button {
-  background: #fff;
+  background: var(--bg-raised);
   color: var(--fg);
   border: 1px solid var(--line-strong);
   border-radius: 999px;
@@ -313,11 +313,11 @@ button:focus-visible {
   font-family: var(--font-sans);
   transition: all 180ms;
 }
-.filter button:hover { border-color: var(--i2-navy-900); }
+.filter button:hover { border-color: var(--fg); }
 .filter button.is-active {
-  background: var(--i2-navy-900);
-  color: #fff;
-  border-color: var(--i2-navy-900);
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
 }
 
 .project-grid {
@@ -326,7 +326,7 @@ button:focus-visible {
   gap: 16px;
 }
 .project-card {
-  background: #fff;
+  background: var(--bg-raised);
   border: 1px solid var(--line);
   border-radius: 18px;
   padding: 28px;
@@ -411,7 +411,7 @@ button:focus-visible {
   gap: 16px;
 }
 .step {
-  background: #fff;
+  background: var(--bg-raised);
   border: 1px solid var(--line);
   border-radius: 18px;
   padding: 28px;
@@ -583,7 +583,7 @@ button:focus-visible {
   padding: 0 24px;
 }
 .placeholder-card {
-  background: #fff;
+  background: var(--bg-raised);
   border: 1px solid var(--line);
   border-radius: 18px;
   padding: 48px;
@@ -706,7 +706,7 @@ button:focus-visible {
   gap: 16px;
 }
 .venture-card {
-  background: #fff;
+  background: var(--bg-raised);
   border: 1px solid var(--line);
   border-radius: 18px;
   padding: 24px;
@@ -735,7 +735,7 @@ button:focus-visible {
 .venture-table {
   width: 100%;
   border-collapse: collapse;
-  background: #fff;
+  background: var(--bg-raised);
   border: 1px solid var(--line);
   border-radius: 18px;
   overflow: hidden;
@@ -837,6 +837,50 @@ button:focus-visible {
   .quote { padding: 48px 24px; margin: 64px 16px 0; }
   .container { padding-inline: 16px; }
   .footer { padding: 40px 16px 32px; }
+}
+
+/* ---------- Theme toggle ---------- */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px; height: 40px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--line-strong);
+  color: var(--fg);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--dur-base) var(--ease-out),
+              border-color var(--dur-base) var(--ease-out),
+              color var(--dur-base) var(--ease-out);
+}
+.theme-toggle:hover { border-color: var(--fg); background: var(--bg-sunken); }
+.theme-toggle svg { width: 18px; height: 18px; }
+.theme-toggle .icon-sun  { display: none; }
+.theme-toggle .icon-moon { display: block; }
+
+/* Dark-theme tints for translucent nav surfaces and link hovers.
+   Light tokens for these can't be expressed as variables alone because
+   they involve alpha over a non-token base, so we override directly. */
+:root[data-theme="dark"] {
+  --nav-bg: rgba(8, 24, 42, 0.55);
+  --nav-bg-scrolled: rgba(8, 24, 42, 0.85);
+  --nav-link-hover: rgba(255, 255, 255, 0.06);
+  --nav-link-active: rgba(255, 255, 255, 0.1);
+}
+:root[data-theme="dark"] .theme-toggle .icon-sun  { display: block; }
+:root[data-theme="dark"] .theme-toggle .icon-moon { display: none; }
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] {
+    --nav-bg: rgba(8, 24, 42, 0.55);
+    --nav-bg-scrolled: rgba(8, 24, 42, 0.85);
+    --nav-link-hover: rgba(255, 255, 255, 0.06);
+    --nav-link-active: rgba(255, 255, 255, 0.1);
+  }
+  :root[data-theme="auto"] .theme-toggle .icon-sun  { display: block; }
+  :root[data-theme="auto"] .theme-toggle .icon-moon { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -159,8 +159,14 @@
 }
 
 /* ============================================================
-   Dark surface -opt-in by adding `.on-dark` to a section
+   Dark theme tokens
+   Applied site-wide when:
+     - the user has explicitly chosen dark (html[data-theme="dark"]), OR
+     - the user is on "auto" (the default) and the OS prefers dark.
+   The `.on-dark` class keeps its old job: a localised dark surface
+   (hero, quote, dark cards) that stays dark regardless of theme.
    ============================================================ */
+:root[data-theme="dark"],
 .on-dark {
   --bg: var(--i2-navy-900);
   --bg-raised: var(--i2-navy-800);
@@ -175,6 +181,27 @@
   --line-strong: rgba(255, 255, 255, 0.16);
   --link: var(--i2-ink-50);
   --link-hover: var(--i2-signal-400);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] {
+    --bg: var(--i2-navy-900);
+    --bg-raised: var(--i2-navy-800);
+    --bg-sunken: var(--i2-navy-950);
+    --bg-inverse: var(--i2-ink-50);
+    --fg: var(--i2-ink-50);
+    --fg-body: #d8d3c5;
+    --fg-muted: #9aa1ab;
+    --fg-subtle: #6c7480;
+    --fg-inverse: var(--i2-ink-900);
+    --line: rgba(255, 255, 255, 0.08);
+    --line-strong: rgba(255, 255, 255, 0.16);
+    --link: var(--i2-ink-50);
+    --link-hover: var(--i2-signal-400);
+  }
+}
+
+.on-dark {
   background: var(--bg);
   color: var(--fg-body);
 }

--- a/thesis/index.html
+++ b/thesis/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 <link rel="stylesheet" href="../styles/tokens.css">
 <link rel="stylesheet" href="../styles/site.css">
+<script>(function(){try{var t=localStorage.getItem('i2-theme');document.documentElement.setAttribute('data-theme',t==='light'||t==='dark'?t:'auto');}catch(e){document.documentElement.setAttribute('data-theme','auto');}})();</script>
 </head>
 <body class="i2">
 <a class="skip-link" href="#main">Skip to main content</a>
@@ -21,6 +22,10 @@
       <a href="../studio/"   data-nav="/studio/">Studio</a>
       <a href="../journal/"  data-nav="/journal/">Journal</a>
     </nav>
+    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m4.93 19.07 1.41-1.41"/><path d="m17.66 6.34 1.41-1.41"/></svg>
+    </button>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg>
     </button>

--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
 <link rel="stylesheet" href="../../styles/tokens.css">
 <link rel="stylesheet" href="../../styles/site.css">
+<script>(function(){try{var t=localStorage.getItem('i2-theme');document.documentElement.setAttribute('data-theme',t==='light'||t==='dark'?t:'auto');}catch(e){document.documentElement.setAttribute('data-theme','auto');}})();</script>
 </head>
 <body class="i2">
 <a class="skip-link" href="#main">Skip to main content</a>
@@ -21,6 +22,10 @@
       <a href="../../studio/"   data-nav="/studio/">Studio</a>
       <a href="../../journal/"  data-nav="/journal/">Journal</a>
     </nav>
+    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m4.93 19.07 1.41-1.41"/><path d="m17.66 6.34 1.41-1.41"/></svg>
+    </button>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg>
     </button>

--- a/ventures/index.html
+++ b/ventures/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 <link rel="stylesheet" href="../styles/tokens.css">
 <link rel="stylesheet" href="../styles/site.css">
+<script>(function(){try{var t=localStorage.getItem('i2-theme');document.documentElement.setAttribute('data-theme',t==='light'||t==='dark'?t:'auto');}catch(e){document.documentElement.setAttribute('data-theme','auto');}})();</script>
 </head>
 <body class="i2">
 <a class="skip-link" href="#main">Skip to main content</a>
@@ -21,6 +22,10 @@
       <a href="../studio/"   data-nav="/studio/">Studio</a>
       <a href="../journal/"  data-nav="/journal/">Journal</a>
     </nav>
+    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m4.93 19.07 1.41-1.41"/><path d="m17.66 6.34 1.41-1.41"/></svg>
+    </button>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg>
     </button>

--- a/ventures/pairflix/index.html
+++ b/ventures/pairflix/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg">
 <link rel="stylesheet" href="../../styles/tokens.css">
 <link rel="stylesheet" href="../../styles/site.css">
+<script>(function(){try{var t=localStorage.getItem('i2-theme');document.documentElement.setAttribute('data-theme',t==='light'||t==='dark'?t:'auto');}catch(e){document.documentElement.setAttribute('data-theme','auto');}})();</script>
 </head>
 <body class="i2">
 <a class="skip-link" href="#main">Skip to main content</a>
@@ -21,6 +22,10 @@
       <a href="../../studio/"   data-nav="/studio/">Studio</a>
       <a href="../../journal/"  data-nav="/journal/">Journal</a>
     </nav>
+    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m4.93 19.07 1.41-1.41"/><path d="m17.66 6.34 1.41-1.41"/></svg>
+    </button>
     <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-controls="nav-links" aria-expanded="false">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/></svg>
     </button>


### PR DESCRIPTION
## Summary

Adds a sun/moon theme toggle to the nav across every page. The site defaults to the OS `prefers-color-scheme` preference; once a user picks light or dark explicitly the choice is persisted in `localStorage` and respected on later visits. While in "auto" the page tracks OS changes live, and the choice syncs across open tabs.

- `styles/tokens.css` — dark theme tokens apply to `:root[data-theme="dark"]` and to `:root[data-theme="auto"]` under `@media (prefers-color-scheme: dark)`. The existing `.on-dark` class keeps its job as a localised dark surface (hero, quote, dark venture cards).
- `styles/site.css` — hardcoded `#fff` card surfaces now use `var(--bg-raised)` so they invert with the theme. Nav translucent tints and link hovers pull from `--nav-*` CSS vars that the dark blocks override. `btn-secondary` uses semantic `fg`/`bg` so it stays legible on dark.
- `scripts/site.js` — small theme controller: reads the store, applies the attribute, toggles, persists, listens for OS changes (in auto) and `storage` events (cross-tab).
- HTML pages — an inline pre-paint script in `<head>` sets `data-theme` before first paint to avoid a flash, and a theme-toggle button is wired into the nav next to the mobile menu button.

## Test plan

- [ ] Open the homepage with system theme = light → site is light, moon icon shown.
- [ ] Switch system theme to dark with no stored preference → site flips to dark, sun icon shown, no FOUC on reload.
- [ ] Click the toggle → theme flips, persists across reloads, and overrides the OS preference.
- [ ] Open two tabs, toggle in one → other tab updates.
- [ ] Check each page (index, ventures, ventures/adopt-dont-shop, ventures/pairflix, thesis, studio, journal) renders correctly in both themes — especially the hero, stats grid, project cards, "how it works" steps, venture detail cards and tables, and the footer.
- [ ] Mobile width: theme toggle remains visible next to the hamburger.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PTQ8JiuT9h7EKDMgByoZX)_