### PR TITLE
feat(ventures): update AdoptDontShop alpha status — microservices migration complete

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,7 +184,7 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Rescue search &amp; discovery, application document upload, automated content moderation, and application statistics now live. Microservices migration complete &mdash; all ten service verticals (notifications, auth, pets, rescue, applications, moderation, matching, audit, storage and gateway) run as independent gRPC services behind a strangler-fig gateway, all containerised and flip-ready.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>


### PR DESCRIPTION
## Summary

- Updates the "Shipped in the alpha" copy on the AdoptDontShop venture page to reflect what shipped on 6 June 2026
- Calls the microservices migration **complete** (was "now underway") — all ten verticals are extracted and flip-ready
- Adds four new customer-facing capabilities: rescue search & discovery, application document upload, automated content moderation, and application statistics

## What changed in the codebase (today's PRs)

| PR | What it does |
|---|---|
| #953 | Rescue search, featured rescues, nearby stub, registration |
| #952 | Automated content moderation via NATS (chat, listings, applications) |
| #951 | Matching recommendations wired to frontend contracts |
| #950 | Application document upload / list / remove end-to-end |
| #949 | Reusable storage package (local + S3) |
| #948 / #947 | Pets gateway adapters (read + write) |
| #946 | All services containerised |
| #942–#945 | Application stats, document metadata RPCs, cutover readiness |

## Notion changelog

Also updated the Notion Changelog / Release Notes page and the AdoptDontShop project page with these entries and the updated migration status.

## Test plan

- [ ] Verify the "Shipped in the alpha" card text reads correctly on the venture page
- [ ] Confirm no other copy on the page conflicts with the updated migration status

https://claude.ai/code/session_01Rd6cJEvfzq1WaysSnFZXXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rd6cJEvfzq1WaysSnFZXXR)_