### PR TITLE
chore(ventures): reflect ADS microservices migration completion

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,7 +184,7 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time chat with WebSocket fan-out, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration complete &mdash; all ten domain services now run as independent gRPC services behind a strangler-fig gateway, with zero breaking changes for client apps.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>


### PR DESCRIPTION
## Summary

- Updates the AdoptDontShop venture page "Shipped in the alpha" status card to reflect that the microservices migration is **complete**, not underway
- Replaces the outdated "real-time messaging on Socket.io" reference with "real-time chat with WebSocket fan-out" (the chat service now runs as an independent gRPC vertical)

## Context

25 PRs merged into adopt-dont-shop on 6–7 June 2026 completed the full microservices gateway surface across all ten domain services (auth, pets, rescue, applications, matching, notifications, chat, moderation, audit, storage). The website still described this as in-progress.

The Notion Changelog / Release Notes page has been updated separately with the full customer-facing entry list for both ADS (June 7 sprint) and Pairflix (already current).

## Test plan

- [ ] View `/ventures/adopt-dont-shop/` — "Shipped in the alpha" card reads correctly
- [ ] Pairflix page unchanged

https://claude.ai/code/session_01CsKaoKytsJfqh4maAspux5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsKaoKytsJfqh4maAspux5)_