### PR TITLE
feat(ventures): update AdoptDontShop status for June 8 releases

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,7 +184,7 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration complete &mdash; all ten domain services run as independent gRPC services behind a strangler-fig gateway. Latest additions: CMS-managed content and menus, field-level permission controls per staff role, and image upload with signed URL delivery.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Corrects "Microservices migration now underway" → "complete" (all ten domain services shipped)
- Adds the three features merged into adopt-dont-shop on 8 June 2026: CMS-managed content and menus, field-level permission controls per staff role, and image upload with signed URL delivery

## Notion changelog

The Changelog / Release Notes Notion page (`1af1f6f299ab4477b8702cf201e06a7e`) was updated in the same pass — three new ✅ entries added to the AdoptDontShop v0.x June 2026 section.

## Test plan

- [ ] Load `/ventures/adopt-dont-shop/` and confirm "Shipped in the alpha" card reads correctly
- [ ] Confirm no other sections were changed

https://claude.ai/code/session_01ANT5hSfqABvXRpv7EP5DaE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANT5hSfqABvXRpv7EP5DaE)_