### PR TITLE
feat(ventures): reflect June 9 AdoptDontShop alpha progress

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,7 +184,7 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration complete &mdash; all ten domain services now run as independent gRPC services behind a strangler-fig gateway. GDPR right-to-erasure, admin broadcast notifications and saved analytics reports also shipped.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>


### PR DESCRIPTION
## Summary

- Updates the "Shipped in the alpha" card on the AdoptDontShop venture page to reflect current state
- Corrects the microservices migration status from "underway / in progress" to "complete" (all ten domain services migrated)
- Adds the three features that shipped on 9 June 2026: GDPR right-to-erasure, admin broadcast notifications, and saved analytics reports

## Test plan

- [ ] Review the AdoptDontShop venture page copy — "Shipped in the alpha" card should mention completed migration and three new features
- [ ] Confirm Pairflix page is unchanged
- [ ] Confirm no broken links or layout issues

https://claude.ai/code/session_01UBkf9rLu2Ei2kP3wisuaqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBkf9rLu2Ei2kP3wisuaqu)_