### PR TITLE
feat(ads): update status section to reflect completed microservices migration

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,11 +184,11 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration complete (Phase 11) &mdash; all ten domain services (auth, pets, rescue, applications, matching, notifications, chat, moderation, audit, storage) now run as independent gRPC microservices behind a strangler-fig gateway; the legacy monolith has been fully deleted. Security hardening includes non-root production containers, fully parameterised CMS queries, and authenticated WebSocket handshakes.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>
-      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. Services communicate over gRPC + NATS as the platform migrates to a domain-per-service architecture.</p>
+      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Fastify + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. All ten domain services communicate over gRPC + NATS JetStream in a fully distributed microservices architecture; the monolith is gone.</p>
     </article>
     <article class="venture-card">
       <h4>Demand signal preserved</h4>


### PR DESCRIPTION
## Summary

- Updates the AdoptDontShop venture page "Shipped in the alpha" card: microservices migration is now **complete** (Phase 11 deleted the monolith), not underway. Adds security hardening callout (non-root containers, parameterised CMS queries, authenticated WebSocket handshakes).
- Updates the "Three frontends, one platform" card: changes "migrates to a domain-per-service architecture" → "fully distributed microservices architecture; the monolith is gone", and notes NATS JetStream as the event bus.

## Test plan

- [ ] Load `/ventures/adopt-dont-shop/` and verify the status section reads as migration-complete, not in-progress
- [ ] Check that no other copy on the page contradicts the completed migration claim

https://claude.ai/code/session_019QDtxoEg1uD796anQFJ4E7

---
_Generated by [Claude Code](https://claude.ai/code/session_019QDtxoEg1uD796anQFJ4E7)_