### PR TITLE
feat(ventures): update AdoptDontShop status — microservices migration complete

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,11 +184,11 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging, GDPR right-to-erasure, full audit trail with payload redaction, field-level permissions, and CMS. Microservices migration complete &mdash; all ten domain services run independently behind the API gateway; Redis-backed rate limiting and per-service circuit breakers are live. CI gates all merges on service tests and E2E.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>
-      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. Services communicate over gRPC + NATS as the platform migrates to a domain-per-service architecture.</p>
+      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Fastify + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. Ten independent gRPC microservices communicate over NATS JetStream; the API gateway handles rate limiting, circuit breaking and distributed tracing via OpenTelemetry.</p>
     </article>
     <article class="venture-card">
       <h4>Demand signal preserved</h4>


### PR DESCRIPTION
## Summary

- Removes stale "microservices migration now underway" copy from the AdoptDontShop status section — the migration is complete (all 10 domain services independent, monolith deleted in Phase 11)
- Updates "Shipped in the alpha" card to surface current platform capabilities: Redis-backed rate limiting, per-service circuit breakers, GDPR audit hardening, and CI merge gating
- Updates tech stack card: Express → Fastify, drops "migrating to domain-per-service" qualifier, adds NATS JetStream + OpenTelemetry + circuit breaking callouts

## Context

Five PRs merged to adopt-dont-shop in the last 24 hours (PRs #1011, #1013, #1016, #1017, #1018) completing the microservices migration, adding gateway resilience (circuit breakers, rate limiting), audit redaction, GDPR saga hardening, and CI gating. The website copy did not reflect any of this.

Notion changelog (ideaSquared HQ → Commercial → Changelog / Release Notes) updated separately with 5 new bullet points covering the new platform capabilities.

## Test plan

- [ ] Review the AdoptDontShop venture page copy reads accurately and is not misleading to investors or rescue partners
- [ ] No broken links or layout issues introduced

https://claude.ai/code/session_01VTdmD8kwPv7S3BoCoF2o21

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTdmD8kwPv7S3BoCoF2o21)_