### PR TITLE
docs(ads): update status copy for completed microservices migration and security hardening

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,11 +184,11 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, Sigstore container signing, and GDPR right-to-erasure with idempotent request handling. Microservices migration complete &mdash; all ten domain services run as independent gRPC microservices behind the gateway. Latest security hardening adds signed inter-service identity tokens (eliminating internal header forgery) and an auditable deploy safety gate for any CI or signing bypass.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>
-      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. Services communicate over gRPC + NATS as the platform migrates to a domain-per-service architecture.</p>
+      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. All ten domain services run as independent gRPC microservices over NATS JetStream &mdash; the monolith-to-microservices migration is complete.</p>
     </article>
     <article class="venture-card">
       <h4>Demand signal preserved</h4>


### PR DESCRIPTION
## Summary

- Fixes stale copy in the AdoptDontShop venture page that described the microservices migration as still underway — the monolith was fully deleted in Phase 11; all ten domain services are now running as independent gRPC microservices
- Updates the "Three frontends, one platform" card to reflect the completed migration
- Adds the latest security milestones shipped on 12 Jun 2026 to "Shipped in the alpha": signed inter-service identity tokens, GDPR erasure idempotency/rate-limiting, and the deploy safety gate with audit trail

## Test plan

- [ ] Verify the ADS venture page renders correctly with the updated copy
- [ ] Confirm no broken links or layout regressions in the status section

https://claude.ai/code/session_01QMWjbEu83kzwU1i4jzv3ZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMWjbEu83kzwU1i4jzv3ZP)_