### PR TITLE
feat(ventures): update AdoptDontShop status page to reflect completed migration

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,11 +184,11 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging, field-level permissions, CMS, GDPR right-to-erasure, admin broadcasts, and saved analytics reports. Pet images display a clean placeholder when no photo has been uploaded. Microservices migration complete &mdash; all ten domain services now run as independent gRPC microservices; the legacy monolith has been fully removed.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>
-      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. Services communicate over gRPC + NATS as the platform migrates to a domain-per-service architecture.</p>
+      <p>React 18 + Vite + vanilla-extract across the adopter portal (app.client), rescue dashboard (app.rescue) and internal admin (app.admin). Ten domain microservices in TypeScript, each with its own Postgres schema, communicating over gRPC + NATS JetStream behind a Fastify API gateway. Managed with pnpm + Turborepo for fast, cache-aware builds.</p>
     </article>
     <article class="venture-card">
       <h4>Demand signal preserved</h4>


### PR DESCRIPTION
## Summary

- **Microservices migration complete**: the "Shipped in the alpha" card said migration was "now underway" with only notifications and auth extracted. It's done — all ten services are independent, the monolith is deleted. Updated to say so.
- **Tech stack corrected**: the "Three frontends, one platform" card listed `styled-components` (Pairflix's stack) — ADS uses `vanilla-extract`. Also updated to reflect pnpm + Turborepo (migrated from npm workspaces June 12) and Fastify API gateway.
- **Shipped features expanded**: the features list in card 1 now includes CMS, GDPR right-to-erasure, field-level permissions, admin broadcasts, saved analytics reports, and the pet image no-image fallback — all shipped since the last copy update.

## Test plan

- [ ] Visually review `/ventures/adopt-dont-shop/` — three status cards read accurately
- [ ] No layout regressions (pure copy change, no structural HTML change)

https://claude.ai/code/session_01AjcrjU5zfFESTs1fspCY3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjcrjU5zfFESTs1fspCY3h)_