### PR TITLE
feat(ventures): update AdoptDontShop alpha status to reflect current shipped state

### DIFF
--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -184,11 +184,11 @@
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time messaging on Socket.io, full Docker dev + prod environment, OpenTelemetry distributed tracing, and Sigstore container signing. Microservices migration now underway &mdash; notifications and auth run as independent gRPC services behind a strangler-fig gateway, with the pets service extraction in progress.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, real-time chat with unread counts and full-text search, GDPR right-to-erasure, image upload with signed delivery, field-level role permissions, CMS service for rescue-owned content pages, saved analytics reports, full Docker dev + prod environment, OpenTelemetry distributed tracing, Sigstore container signing, and interactive OpenAPI docs. Microservices migration complete &mdash; all ten domain services now run as independent gRPC microservices behind a Fastify gateway; the legacy monolith is fully retired.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>
-      <p>React 18 + Vite + styled-components across the adopter portal, rescue dashboard and internal admin. Node 20 + Express + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. Services communicate over gRPC + NATS as the platform migrates to a domain-per-service architecture.</p>
+      <p>React 18 + Vite + vanilla-extract across the adopter portal, rescue dashboard and internal admin. Fastify gateway + Sequelize on PostgreSQL 16 + PostGIS and Redis 7, fronted by Nginx. All ten domain services communicate over gRPC + NATS JetStream with durable, at-least-once delivery.</p>
     </article>
     <article class="venture-card">
       <h4>Demand signal preserved</h4>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Syncs the AdoptDontShop venture page with the actual current state as recorded in the Notion changelog, correcting several stale descriptions that had fallen behind the build.

**Shipped in the alpha** — expanded the feature list to include:
- Real-time chat with unread counts and full-text search
- GDPR right-to-erasure
- Image upload with signed delivery
- Field-level role permissions
- CMS service for rescue-owned content pages
- Saved analytics reports
- Interactive OpenAPI docs

**Microservices status** — changed "migration now underway — notifications and auth run as independent gRPC services, pets extraction in progress" to "migration complete — all ten domain services now run as independent gRPC microservices; the legacy monolith is fully retired." This is accurate per the changelog (Phase 11 shipped).

**Tech stack** — two factual corrections:
- `styled-components` → `vanilla-extract` (ADS uses vanilla-extract; styled-components is Pairflix)
- `Express` → `Fastify gateway` (the monolith was Express; the current gateway is Fastify)
- "migrates to a domain-per-service architecture" → "all ten domain services communicate over gRPC + NATS JetStream with durable, at-least-once delivery" (migration is done)

## Test plan
- [ ] Read the venture page and confirm all feature claims are accurate against the Notion changelog
- [ ] Confirm no broken links introduced
- [ ] Visual check that card layout is unaffected

https://claude.ai/code/session_01JoUosc5CZwptpzBKACR7Pk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoUosc5CZwptpzBKACR7Pk)_