### PR TITLE
chore(journal): add 16 Jun 2026 ADS entries — auth hardening + data isolation

### DIFF
--- a/journal/index.html
+++ b/journal/index.html
@@ -52,10 +52,28 @@
     <article class="venture-card">
       <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
         <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">16 Jun 2026</span>
+      </div>
+      <h4>Auth security hardening.</h4>
+      <p>Registration no longer reveals whether an email address is already in use &mdash; your privacy is protected regardless of account state. New accounts now require email verification before becoming active. Signing out a device or resetting your password immediately invalidates all related access tokens; previously issued tokens can no longer be replayed.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">16 Jun 2026</span>
+      </div>
+      <h4>Data isolation, notification opt-outs and infrastructure reliability.</h4>
+      <p>Applications are now strictly scoped to the adopter who submitted them; pet listings are correctly isolated to the managing rescue &mdash; no cross-organisation data access is possible. Email notification opt-outs are enforced per notification type, so opting out of one category doesn&rsquo;t affect others. A dead-letter queue now captures any background event that fails processing, eliminating silent data loss.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
         <span style="font-size: 12px; color: var(--fg-muted);">15 Jun 2026</span>
       </div>
       <h4>Email notifications live.</h4>
-      <p>Adopters and rescue staff now receive application updates, new messages and rescue decisions by email as well as in-app. Each account's saved channel preferences are enforced at send time &mdash; if you've opted out of email for a notification type, it stays in-app only. A deduplication guard ensures each alert arrives exactly once.</p>
+      <p>Adopters and rescue staff now receive application updates, new messages and rescue decisions by email as well as in-app. Each account&rsquo;s saved channel preferences are enforced at send time &mdash; if you&rsquo;ve opted out of email for a notification type, it stays in-app only. A deduplication guard ensures each alert arrives exactly once.</p>
     </article>
 
     <article class="venture-card">
@@ -140,7 +158,7 @@
     </article>
     <article class="venture-card">
       <h4>Workflow-breaking only</h4>
-      <p>Bugs noteworthy enough to break a workflow get listed. Trivial fixes don't clutter the page.</p>
+      <p>Bugs noteworthy enough to break a workflow get listed. Trivial fixes don&rsquo;t clutter the page.</p>
     </article>
   </div>
 </section>


### PR DESCRIPTION
## Summary\n\nAdds two new journal entries dated 16 Jun 2026 for AdoptDontShop, covering the significant batch of security and reliability improvements shipped today (PRs #1056–#1065).\n\n**Entry 1 — Auth security hardening:**\n- Registration no longer reveals whether an email is already registered\n- Email verification required before accounts become active\n- Immediate token invalidation on session logout or password reset\n\n**Entry 2 — Data isolation, notification opt-outs, infrastructure reliability:**\n- Applications and pet listings strictly scoped to their owning adopter/rescue\n- Email notification opt-outs enforced per notification type independently\n- Dead-letter queue for failed background events (no more silent data loss)\n\n## What was not included\nInternal chores (dead code removal #1066–1068, nginx dep bump #1045, code quality passes #1053–1054) — these don't affect users and would clutter the journal.\n\n## Notion changelog\nThe internal Changelog / Release Notes page has also been updated with full detail on all 9 customer-relevant commits from today.\n\n## Test plan\n- [ ] Review journal page renders correctly with two new 16 Jun entries at the top\n- [ ] Entries use correct customer-facing language (no commit jargon)\n- [ ] HTML entities are correct (`&mdash;`, `&rsquo;` etc.)

---
_Generated by [Claude Code](https://claude.ai/code/session_011c5PcBUW5YZntyWdVV4i27)_