### PR TITLE
chore(journal): add 17 Jun 2026 ADS entries

### DIFF
--- a/journal/index.html
+++ b/journal/index.html
@@ -52,6 +52,24 @@
     <article class="venture-card">
       <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
         <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">17 Jun 2026</span>
+      </div>
+      <h4>Login restored after gateway migration.</h4>
+      <p>Following the switch from the legacy monolith to the new Fastify API gateway, the adopter portal had an auth contract mismatch that prevented users from signing in. The contract is now aligned &mdash; login works correctly end-to-end across the adopter portal, rescue dashboard and admin panel.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">17 Jun 2026</span>
+      </div>
+      <h4>Adopters can now update their own notification preferences.</h4>
+      <p>A permissions gap meant adopters could not save changes to their notification settings without triggering an authorisation error. Each account can now update its own channel preferences &mdash; in-app vs. email, per notification type &mdash; without requiring a staff intervention.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
         <span style="font-size: 12px; color: var(--fg-muted);">16 Jun 2026</span>
       </div>
       <h4>Auth security hardening.</h4>


### PR DESCRIPTION
## Summary

Two new journal entries for 17 Jun 2026, covering the workflow-breaking ADS fixes shipped today:

- **Login restored after gateway migration** — the Fastify gateway / SPA auth contract mismatch that was preventing login is fixed; all three frontends now authenticate correctly end-to-end.
- **Adopter notification preferences now self-service** — the ADS-869 permissions gap that blocked adopters from saving their own notification channel settings is resolved.

No venture-page changes needed — the "Shipped in the alpha" card already reflects the overall security hardening and the stack is unchanged.

## Source commits (adopt-dont-shop)
- `fix(auth): align gateway↔SPA auth contract so login works (#1076)`
- `fix(auth): grant adopters self-scoped notification writes (ADS-869) (#1085)`

## Notion changelog
Updated simultaneously — both items prepended to the ADS `v0.x — In build · June 2026` section.

---
_Generated by [Claude Code](https://claude.ai/code/session_015baJF8n2tNHKXSRqepH28a)_