### PR TITLE
chore(journal): add 19-20 Jun 2026 ADS entries

### DIFF
--- a/journal/index.html
+++ b/journal/index.html
@@ -52,6 +52,33 @@
     <article class="venture-card">
       <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
         <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">20 Jun 2026</span>
+      </div>
+      <h4>Personalised pet recommendations and application pre-fill.</h4>
+      <p>The home page and a new Top Picks page now surface personalised pet recommendations, ranked by your match preferences and recency, each with a plain-language reason for the suggestion. Separately, new adoption applications now pre-populate from your saved details, with your defaults updated automatically as you apply.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">20 Jun 2026</span>
+      </div>
+      <h4>Rescue profile settings save fixed.</h4>
+      <p>Saving changes on the rescue dashboard&rsquo;s Settings page was failing with an error; profile updates now save correctly.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">19 Jun 2026</span>
+      </div>
+      <h4>Security: inline stylesheet injection vector closed.</h4>
+      <p>The platform&rsquo;s Content-Security-Policy no longer permits inline stylesheets, closing a CSS-injection vector. A CI guard now blocks any regression.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
         <span style="font-size: 12px; color: var(--fg-muted);">18 Jun 2026</span>
       </div>
       <h4>Staff invitations, 2FA, pet favourites and custom application questions.</h4>


### PR DESCRIPTION
## Summary
- Backfills the public journal with two AdoptDontShop changelog entries that had been logged in the internal Notion changelog but never published to the site: the 19 Jun CSP/inline-stylesheet fix, and today's (20 Jun) Top Picks + application pre-fill feature and rescue-settings save fix.
- Internal-only admin features shipped today (Security Center sessions, IP allow/block rules) are intentionally excluded, consistent with existing precedent of not surfacing admin-panel-only changes on the public journal.

## Test plan
- [x] Verified against the source-of-truth Notion "Changelog / Release Notes" page, which was updated in the same session
- [ ] Visual check of `/journal/` page render


---
_Generated by [Claude Code](https://claude.ai/code/session_011uJ4Be3dxbc5gnc34WkYLn)_