### PR TITLE
chore(journal): catch up 29 Jun–1 Jul 2026 AdoptDontShop entries

### DIFF
--- a/journal/index.html
+++ b/journal/index.html
@@ -37,7 +37,7 @@
 
 <section class="subpage-hero">
   <span class="eyebrow">The journal</span>
-  <h1>What's shipping across the studio, in the open.</h1>
+  <h1>What&rsquo;s shipping across the studio, in the open.</h1>
   <p>Dated entries from the live ventures, newest first. Each entry links to the <a href="../ventures/">venture brief</a> for the full current snapshot &mdash; roadmap, stack and stage.</p>
 </section>
 
@@ -48,6 +48,33 @@
     <p>One line per change, tagged with the venture it belongs to.</p>
   </div>
   <div class="venture-grid-2">
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">1 Jul 2026</span>
+      </div>
+      <h4>API reliability fixes; session security hardened; cold-start wait resolved.</h4>
+      <p>A batch of API schema issues were causing list endpoints to mis-serialise data, DELETE routes to reject valid requests, and the matching top-picks endpoint to return malformed responses &mdash; all fixed, with the interactive API docs at /docs now accurately reflecting every endpoint. Refresh tokens are now stored as one-way hashes, so a database exposure can no longer be used to impersonate an active session. The adopter portal, rescue dashboard and admin panel no longer return errors for &sim;40 seconds after a cold boot &mdash; all three now wait for the API gateway to become healthy before serving.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">30 Jun 2026</span>
+      </div>
+      <h4>Rescue events live; live analytics dashboard; profile saves fixed; security: account tokens hardened.</h4>
+      <p>Rescues can now create and manage adoption events, fundraisers, volunteer days and community meetups &mdash; attendees can register and check in, and event analytics track attendance and capacity. The rescue dashboard analytics page now shows real figures for adoption trends, application status, pet performance and top breeds (mock data removed). Account profile changes that were silently failing now save correctly. Password-reset and email-verification tokens are now stored as SHA-256 hashes, closing a vector where a database read could produce valid account-takeover links.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">29 Jun 2026</span>
+      </div>
+      <h4>Analytics reports: run, schedule &amp; share; rescue adoption policy fix; application security.</h4>
+      <p>Rescue analytics reports can now be executed for live figures, previewed, scheduled for recurring delivery and shared with team members. Saving changes to a rescue&rsquo;s adoption policy on the Settings page no longer returns an error. Adoption applications now derive the applicant&rsquo;s identity exclusively from the authenticated session, closing a gap where a crafted request body could submit an application as another user.</p>
+    </article>
 
     <article class="venture-card">
       <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">

--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -157,7 +157,7 @@
   <div class="head">
     <span class="eyebrow">Go-to-market</span>
     <h2 id="gtm">Cluster, then influence, then national.</h2>
-    <p>Two-sided marketplaces don't survive a national cold start. We onboard density first.</p>
+    <p>Two-sided marketplaces don&rsquo;t survive a national cold start. We onboard density first.</p>
   </div>
   <div class="venture-grid-3">
     <article class="venture-card">
@@ -177,14 +177,14 @@
 
 <section class="venture-section" aria-labelledby="status">
   <div class="head">
-    <span class="eyebrow">Where we are &middot; June 2026</span>
+    <span class="eyebrow">Where we are &middot; July 2026</span>
     <h2 id="status">Alpha build is feature-complete. Compliance is the gate.</h2>
     <p>The core adoption flow ships end-to-end in the alpha. The path to closed beta now runs through legal foundation, the data protection package and platform hardening &mdash; not more product code.</p>
   </div>
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, rescue search &amp; discovery, real-time chat with unread counts and full-text search, email and in-app notifications with per-account channel preferences, admin broadcasts, document and image upload with signed delivery, automated content moderation, matching recommendations, saved analytics reports, a CMS for rescue-owned content pages, field-level role permissions, two-factor authentication (TOTP), per-user pet favourites, rescue custom application questions, staff invitation accept, GDPR right-to-erasure, personalised pet recommendations (Top Picks), autosaving application drafts, and account sanction notices. Microservices migration <strong>complete</strong> &mdash; all ten domain services (auth, pets, rescue, applications, notifications, chat, moderation, matching, audit, storage) run as independent gRPC containers behind the API gateway and the legacy monolith is deleted, with Redis-backed rate limiting, per-service circuit breakers, OpenTelemetry distributed tracing, Sigstore container signing, and full Docker dev + prod environments. Security hardening pass done: signed inter-service identity tokens, a full audit trail with payload redaction, an auditable deploy safety gate, interactive OpenAPI docs gated behind admin auth, all high-severity static-analysis findings resolved, and CI gating every merge on service tests and E2E.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, rescue search &amp; discovery, real-time chat with unread counts and full-text search, email and in-app notifications with per-account channel preferences, admin broadcasts, document and image upload with signed delivery, automated content moderation, matching recommendations, saved analytics reports, a CMS for rescue-owned content pages, field-level role permissions, two-factor authentication (TOTP), per-user pet favourites, rescue custom application questions, staff invitation accept, GDPR right-to-erasure, personalised pet recommendations (Top Picks), autosaving application drafts, account sanction notices, rescue events (adoption days, fundraisers, volunteer days and community meetups with attendee check-in and capacity analytics), and a live rescue analytics dashboard with real-time figures across adoption trends, application status, pet performance and top breeds. Microservices migration <strong>complete</strong> &mdash; all ten domain services (auth, pets, rescue, applications, notifications, chat, moderation, matching, audit, storage) run as independent gRPC containers behind the API gateway and the legacy monolith is deleted, with Redis-backed rate limiting, per-service circuit breakers, OpenTelemetry distributed tracing, Sigstore container signing, and full Docker dev + prod environments. Security hardening pass done: signed inter-service identity tokens, a full audit trail with payload redaction, an auditable deploy safety gate, interactive OpenAPI docs gated behind admin auth, all high-severity static-analysis findings resolved, CI gating every merge on service tests and E2E, and one-way hashing for all session, password-reset and email-verification tokens so a database exposure cannot be used to take over an account or replay a session.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>
@@ -278,14 +278,14 @@
     </article>
     <article class="venture-card">
       <h4>&ldquo;Adopt first&rdquo; before &ldquo;buy&rdquo;</h4>
-      <p>The cultural shift we're after &mdash; making adoption the default expectation, not the more difficult option.</p>
+      <p>The cultural shift we&rsquo;re after &mdash; making adoption the default expectation, not the more difficult option.</p>
     </article>
   </div>
 </section>
 
 <section class="quote" aria-label="Founder note">
   <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--i2-signal-400)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 21V11a4 4 0 0 1 4-4h2v3H7a1 1 0 0 0-1 1v2h3v8z"/><path d="M14 21V11a4 4 0 0 1 4-4h2v3h-2a1 1 0 0 0-1 1v2h3v8z"/></svg>
-  <blockquote>&ldquo;The path to adoption should be simpler than the path to a breeder. Today it's the opposite.&rdquo;</blockquote>
+  <blockquote>&ldquo;The path to adoption should be simpler than the path to a breeder. Today it&rsquo;s the opposite.&rdquo;</blockquote>
   <div class="quote-attrib">
     <div class="quote-avatar" aria-hidden="true"></div>
     <div>


### PR DESCRIPTION
## Summary\n\nThe public website journal was stuck at 23 Jun 2026 while the internal Notion changelog had grown by eight customer-facing entries covering 29 Jun–1 Jul. This PR closes that gap.\n\n### Journal entries added (`journal/index.html`)\n\n**1 Jul 2026** — API reliability fixes; session security hardened; cold-start wait resolved  \nAPI schema issues were causing list endpoints to mis-serialise data, DELETE routes to reject valid requests, and the matching top-picks endpoint to return malformed responses — all fixed. Refresh tokens are now stored as one-way hashes (database exposure can no longer impersonate a session). Frontend apps no longer error for ~40 s after a cold boot.\n\n**30 Jun 2026** — Rescue events live; live analytics dashboard; profile saves fixed; account tokens hardened  \nRescues can create adoption events, fundraisers, volunteer days and community meetups with attendee check-in and capacity analytics. The rescue dashboard analytics page now shows real data (mock data removed). Profile changes that were silently failing now save. Password-reset and email-verification tokens are SHA-256 hashed.\n\n**29 Jun 2026** — Analytics reports: run, schedule & share; rescue adoption policy fix; application security  \nAnalytics reports can be executed for live figures, previewed, scheduled and shared. Rescue adoption policy saves correctly. Applications now derive identity exclusively from the authenticated session (crafted body override closed).\n\n### Venture page updated (`ventures/adopt-dont-shop/index.html`)\n\n- Status eyebrow bumped from **June 2026** to **July 2026**\n- \"Shipped in the alpha\" list extended with: rescue events (adoption days, fundraisers, volunteer days, community meetups with check-in and capacity analytics) and the live rescue analytics dashboard\n- Security hardening line updated to note one-way hashing for session, password-reset and email-verification tokens\n\n## Test plan\n\n- [ ] Open `journal/index.html` locally — confirm three new entries appear at the top of the grid in date order (1 Jul, 30 Jun, 29 Jun) above the existing 23 Jun card\n- [ ] Open `ventures/adopt-dont-shop/index.html` locally — confirm \"July 2026\" in the status eyebrow, rescue events and live analytics in the \"Shipped in the alpha\" card, and updated security hardening line\n- [ ] No broken links, no HTML validation errors\n- [ ] Light and dark themes render correctly"

---
_Generated by [Claude Code](https://claude.ai/code/session_014C7jTmtR8riLA3AV5mbPTq)_