### PR TITLE
chore(journal): catch up 29 Jun–1 Jul 2026 ADS entries + Pairflix Phase F

### DIFF
--- a/journal/index.html
+++ b/journal/index.html
@@ -37,7 +37,7 @@
 
 <section class="subpage-hero">
   <span class="eyebrow">The journal</span>
-  <h1>What's shipping across the studio, in the open.</h1>
+  <h1>What&rsquo;s shipping across the studio, in the open.</h1>
   <p>Dated entries from the live ventures, newest first. Each entry links to the <a href="../ventures/">venture brief</a> for the full current snapshot &mdash; roadmap, stack and stage.</p>
 </section>
 
@@ -48,6 +48,33 @@
     <p>One line per change, tagged with the venture it belongs to.</p>
   </div>
   <div class="venture-grid-2">
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">1 Jul 2026</span>
+      </div>
+      <h4>Security: session tokens hardened; API contract corrections; cold-start reliability.</h4>
+      <p>Refresh tokens are now stored as one-way hashes &mdash; a database exposure can no longer be used to hijack an active session. A schema correction resolves issues where some list and delete endpoints were mis-handling requests; all 939 API gateway tests now pass. The adopter portal, rescue dashboard and admin panel no longer show errors for ~40 seconds after a cold boot while the gateway warms up.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">30 Jun 2026</span>
+      </div>
+      <h4>Rescue events; live analytics; profile saves fixed; password-reset tokens hardened.</h4>
+      <p>Rescues can now create and publish events &mdash; adoption days, fundraisers, volunteer days and community meetups &mdash; with attendee registration, check-in and live capacity analytics. The rescue dashboard analytics page now shows real-time figures for adoption trends, application status, pet performance and top breeds; mock data placeholders have been removed. Profile changes on rescue dashboards now save correctly after a routing mismatch introduced during the gateway migration. Password-reset and email-verification links are now backed by SHA-256 hashes, closing a window where a database snapshot could have produced valid account-takeover links.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip signal">AdoptDontShop</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">29 Jun 2026</span>
+      </div>
+      <h4>Saved reports: run, schedule and share; adoption policy saves; application identity locked.</h4>
+      <p>Rescue analytics reports can now be run to produce live figures, previewed, scheduled for recurring delivery, and shared with team members &mdash; delivering the saved-reports feature end-to-end. Changes to a rescue&rsquo;s adoption policy on the Settings page now save correctly after previously returning an error. Adoption applications now derive the applicant&rsquo;s identity from the authenticated session only, closing a gap where a crafted request could have submitted an application as a different user.</p>
+    </article>
 
     <article class="venture-card">
       <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
@@ -155,6 +182,15 @@
       </div>
       <h4>Microservices migration complete. Security hardening pass done.</h4>
       <p>All ten domain services now run as independent containers &mdash; the legacy monolith is deleted. Separately: all high-severity findings from an automated static-analysis security audit have been resolved, and the API documentation page is now gated behind admin credentials. The platform is closer to closed beta readiness.</p>
+    </article>
+
+    <article class="venture-card">
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 4px;">
+        <span class="chip">Pairflix</span>
+        <span style="font-size: 12px; color: var(--fg-muted);">2 Jun 2026</span>
+      </div>
+      <h4>Tonight&rsquo;s pick tracks what you chose; provider badges are now launch buttons.</h4>
+      <p>Every recommendation now records its outcome &mdash; accepted, swapped or dismissed &mdash; and per-household 30-day stats surface first-pick acceptance rate alongside per-provider click counts. The platform badges in the Tonight Picker are now deep-link buttons that open Netflix, Prime, Disney+ and friends directly in a new tab.</p>
     </article>
 
     <article class="venture-card">

--- a/ventures/adopt-dont-shop/index.html
+++ b/ventures/adopt-dont-shop/index.html
@@ -157,7 +157,7 @@
   <div class="head">
     <span class="eyebrow">Go-to-market</span>
     <h2 id="gtm">Cluster, then influence, then national.</h2>
-    <p>Two-sided marketplaces don't survive a national cold start. We onboard density first.</p>
+    <p>Two-sided marketplaces don&rsquo;t survive a national cold start. We onboard density first.</p>
   </div>
   <div class="venture-grid-3">
     <article class="venture-card">
@@ -177,14 +177,14 @@
 
 <section class="venture-section" aria-labelledby="status">
   <div class="head">
-    <span class="eyebrow">Where we are &middot; June 2026</span>
+    <span class="eyebrow">Where we are &middot; July 2026</span>
     <h2 id="status">Alpha build is feature-complete. Compliance is the gate.</h2>
     <p>The core adoption flow ships end-to-end in the alpha. The path to closed beta now runs through legal foundation, the data protection package and platform hardening &mdash; not more product code.</p>
   </div>
   <div class="venture-grid-3">
     <article class="venture-card">
       <h4>Shipped in the alpha</h4>
-      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, rescue search &amp; discovery, real-time chat with unread counts and full-text search, email and in-app notifications with per-account channel preferences, admin broadcasts, document and image upload with signed delivery, automated content moderation, matching recommendations, saved analytics reports, a CMS for rescue-owned content pages, field-level role permissions, two-factor authentication (TOTP), per-user pet favourites, rescue custom application questions, staff invitation accept, GDPR right-to-erasure, personalised pet recommendations (Top Picks), autosaving application drafts, and account sanction notices. Microservices migration <strong>complete</strong> &mdash; all ten domain services (auth, pets, rescue, applications, notifications, chat, moderation, matching, audit, storage) run as independent gRPC containers behind the API gateway and the legacy monolith is deleted, with Redis-backed rate limiting, per-service circuit breakers, OpenTelemetry distributed tracing, Sigstore container signing, and full Docker dev + prod environments. Security hardening pass done: signed inter-service identity tokens, a full audit trail with payload redaction, an auditable deploy safety gate, interactive OpenAPI docs gated behind admin auth, all high-severity static-analysis findings resolved, and CI gating every merge on service tests and E2E.</p>
+      <p>Auth, rescue verification, pet listings with staff permissions, adopter browse/filter/like flow, rescue search &amp; discovery, real-time chat with unread counts and full-text search, email and in-app notifications with per-account channel preferences, admin broadcasts, document and image upload with signed delivery, automated content moderation, matching recommendations, saved analytics reports (run to produce live figures, schedule for recurring delivery, and share with team members), a CMS for rescue-owned content pages, field-level role permissions, two-factor authentication (TOTP), per-user pet favourites, rescue custom application questions, staff invitation accept, GDPR right-to-erasure, personalised pet recommendations (Top Picks), autosaving application drafts, account sanction notices, rescue events (adoption days, fundraisers, volunteer days and community meetups with attendee registration, check-in and live capacity analytics), and live rescue dashboard analytics (real-time adoption trends, application status, pet performance and breed breakdowns). Microservices migration <strong>complete</strong> &mdash; all ten domain services (auth, pets, rescue, applications, notifications, chat, moderation, matching, audit, storage) run as independent gRPC containers behind the API gateway and the legacy monolith is deleted, with Redis-backed rate limiting, per-service circuit breakers, OpenTelemetry distributed tracing, Sigstore container signing, and full Docker dev + prod environments. Security hardening pass done: signed inter-service identity tokens, a full audit trail with payload redaction, an auditable deploy safety gate, interactive OpenAPI docs gated behind admin auth, all high-severity static-analysis findings resolved, and CI gating every merge on service tests and E2E.</p>
     </article>
     <article class="venture-card">
       <h4>Three frontends, one platform</h4>
@@ -278,14 +278,14 @@
     </article>
     <article class="venture-card">
       <h4>&ldquo;Adopt first&rdquo; before &ldquo;buy&rdquo;</h4>
-      <p>The cultural shift we're after &mdash; making adoption the default expectation, not the more difficult option.</p>
+      <p>The cultural shift we&rsquo;re after &mdash; making adoption the default expectation, not the more difficult option.</p>
     </article>
   </div>
 </section>
 
 <section class="quote" aria-label="Founder note">
   <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="var(--i2-signal-400)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 21V11a4 4 0 0 1 4-4h2v3H7a1 1 0 0 0-1 1v2h3v8z"/><path d="M14 21V11a4 4 0 0 1 4-4h2v3h-2a1 1 0 0 0-1 1v2h3v8z"/></svg>
-  <blockquote>&ldquo;The path to adoption should be simpler than the path to a breeder. Today it's the opposite.&rdquo;</blockquote>
+  <blockquote>&ldquo;The path to adoption should be simpler than the path to a breeder. Today it&rsquo;s the opposite.&rdquo;</blockquote>
   <div class="quote-attrib">
     <div class="quote-avatar" aria-hidden="true"></div>
     <div>


### PR DESCRIPTION
## Summary

- **Journal:** adds 4 new entries to bring the public build log current from 23 Jun to 1 Jul 2026
- **ADS venture page:** updates the snapshot date to July 2026 and extends the \"Shipped in the alpha\" list with three new capabilities
- **Notion changelog:** Pairflix Phase F entries date-stamped (2 Jun) — done directly in Notion, not tracked here

## Journal entries added (newest-first)

**1 Jul 2026 — AdoptDontShop**
Session tokens hardened (refresh tokens now one-way hashed), API contract corrections bringing all 939 gateway tests green, and frontend cold-start errors resolved (portals no longer 502 while the gateway warms up).

**30 Jun 2026 — AdoptDontShop**
Rescue events feature (adoption days, fundraisers, volunteer days and community meetups with registration, check-in and analytics); rescue dashboard analytics now live with real data replacing mock placeholders; profile-save routing fix; password-reset and email-verification tokens hardened to SHA-256.

**29 Jun 2026 — AdoptDontShop**
Saved reports end-to-end (run, schedule for recurring delivery, share with team); rescue adoption-policy save fix; application identity locked to authenticated session.

**2 Jun 2026 — Pairflix**
Phase F: pick lifecycle tracking (accepted/swapped/dismissed with 30-day household stats) and provider badges converted to deep-link launch buttons for Netflix, Prime, Disney+ etc.

## ADS venture page changes

- Eyebrow date: \"June 2026\" → \"July 2026\"
- \"Shipped in the alpha\" card: added rescue events, live analytics, and updated saved-reports entry to reflect end-to-end execution/scheduling/sharing capability

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Hd82BAbKkNEud7ZMVnQ9)_